### PR TITLE
hammerhead: wrap a device check around apps to be added

### DIFF
--- a/hammerhead/proprietary/Android.mk
+++ b/hammerhead/proprietary/Android.mk
@@ -1,5 +1,7 @@
 LOCAL_PATH := $(call my-dir)
 
+ifeq ($(TARGET_DEVICE),hammerhead)
+
 include $(CLEAR_VARS)
 LOCAL_MODULE_SUFFIX := $(COMMON_ANDROID_PACKAGE_SUFFIX)
 LOCAL_MODULE := qcrilmsgtunnel
@@ -33,3 +35,4 @@ LOCAL_SRC_FILES := $(LOCAL_MODULE).apk
 LOCAL_CERTIFICATE := PRESIGNED
 include $(BUILD_PREBUILT)
 
+endif


### PR DESCRIPTION
- fixes compilation errors on other devices (like shamu)

Change-Id: Iacf6cd1106ae7d978687c253f8bc0030dee46504
Signed-off-by: Jean-Pierre Rasquin yank555.lu@gmail.com
